### PR TITLE
Increase contrast of neutral stylekit color for search bar cancel button

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -14,8 +14,8 @@
   --sn-stylekit-info-color: var(--highlight-color);
   --sn-stylekit-info-contrast-color: #2e3440;
   --sn-stylekit-info-color-darkened: #5e81ac;
-  --sn-stylekit-neutral-color: #eceff4;
-  --sn-stylekit-neutral-contrast-color: #d8dee9;
+  --sn-stylekit-neutral-color: #4c566a;
+  --sn-stylekit-neutral-contrast-color: #eceff4;
   --sn-stylekit-success-color: #a3be8c;
   --sn-stylekit-success-contrast-color: #eceff4;
   --sn-stylekit-warning-color: #ebcb8b;

--- a/src/main.scss
+++ b/src/main.scss
@@ -22,8 +22,9 @@
   --sn-stylekit-info-color: var(--highlight-color);
   --sn-stylekit-info-contrast-color: #{$nord0};
   --sn-stylekit-info-color-darkened: #{$nord10};
-  --sn-stylekit-neutral-color: #{$nord6};
-  --sn-stylekit-neutral-contrast-color: #{$nord4};
+
+  --sn-stylekit-neutral-color: #{$nord3};
+  --sn-stylekit-neutral-contrast-color: #{$nord6};
 
   --sn-stylekit-success-color: #{$nord14};
   --sn-stylekit-success-contrast-color: #{$nord6};


### PR DESCRIPTION
The cancel button in the search bar did not have a strong between the icon and background when using nord6 for the neutral color and nord4 for the the neutral contrast color. This PR changes the neutral color to nord3 and the neutral contrast color to nord6 leading to a more visible contrast between the icon and background for the search bar cancel button.

**Before**

![image](https://user-images.githubusercontent.com/10442429/117298920-ee5d4b00-ae45-11eb-9ee7-65fccc9a808b.png)

**After**

![image](https://user-images.githubusercontent.com/10442429/117298943-f6b58600-ae45-11eb-9ccc-d6152d642a2f.png)
