### PR TITLE
Ensure active and hovered notes in notes column match the theme

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -44,3 +44,13 @@
   --sn-stylekit-scrollbar-track-border-color: var(--border-color);
   --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color);
 }
+:root #notes-column .note.selected,
+:root .notes .note.selected {
+  background-color: #3b4252;
+}
+:root #notes-column .note:hover,
+:root .notes .note:hover {
+  background-color: #3b4252;
+}
+
+/*# sourceMappingURL=dist.css.map */

--- a/src/main.scss
+++ b/src/main.scss
@@ -63,4 +63,17 @@
 
   --sn-stylekit-scrollbar-track-border-color: var(--border-color);
   --sn-stylekit-scrollbar-thumb-color: var(--sn-stylekit-info-color);
+
+  // Notes column
+  // Ensure the color of the selected note
+  #notes-column .note.selected,
+  .notes .note.selected {
+    background-color: #{$nord1};
+  }
+
+  // Ensure the colur of a hovered over note
+  #notes-column .note:hover,
+  .notes .note:hover {
+    background-color: #{$nord1};
+  }
 }


### PR DESCRIPTION
In the latest version of Standard Notes, the active note or hovered
on note in the column no longer matches the theme, this resolves that
by ensuring the notes in that state are using theme colors